### PR TITLE
Long form export

### DIFF
--- a/R/extractLong.R
+++ b/R/extractLong.R
@@ -153,6 +153,241 @@ getFormData <- function(activity, adminlevels, include.comments) {
   form.data
 }
 
+getFormDimensions <- function(form, prefix = NULL) {
+  dimensions <- vector("list", length(form$elements))
+  dimensions <- setNames(dimensions, lapply(form$elements, function(field) makeColumnName(field$label, prefix)))
+  
+  for (field in form$elements) {
+    # exclude subform fields
+    if (identical(field$type, "subform")) {
+      next
+    } 
+    # exclude measure fields
+    if (identical(field$type, "quantity") || identical(field$type, "calculated")) {
+      next
+    }
+    dimensions[[makeColumnName(field$label, prefix)]] <- field$id
+  }
+  Filter(Negate(is.null), dimensions)
+}
+
+getFormMeasures <- function(form, prefix = NULL) {
+  measures <- vector("list", length(form$elements))
+  measures <- setNames(measures, lapply(form$elements, function(field) makeColumnName(field$label, prefix)))
+
+  for (field in form$elements) {
+    if (identical(field$type, "quantity") || identical(field$type, "calculated")) {
+      measures[[makeColumnName(field$label, prefix)]] <- field$id
+    } 
+  }
+  Filter(Negate(is.null), measures)
+}
+
+#'
+#' @importFrom reshape2 melt
+createDataFrame <- function(records, dimensions, measures, as.value.table = FALSE) {
+  if (is.element("parentId",names(records$columns))) {
+    # Sub-Form
+    df <- data.frame(c(as.data.columns(list(subFormRecordId = records$columns[["subFormRecordId"]], parentId = records$columns[["parentId"]]), records$rows),
+                       as.data.columns(records$columns[names(dimensions)], records$rows),
+                       as.data.columns(records$columns[names(measures)], records$rows)))
+  } else {
+    # Form
+    df <- data.frame(as.data.columns(records$columns, records$rows))
+  }
+  if (as.value.table) {
+    df <- reshape2:::melt.data.frame(df,
+                                     measure.vars = names(measures),
+                                     variable.name = "Quantity",
+                                     value.name = "Value",
+                                     na.rm = TRUE)
+  }
+  return(df)
+}
+
+as.data.column <- function(column, nrows) {
+  if (identical(column$storage, "empty")) {
+    col <- rep(NA, times = nrows)
+  } else {
+    col <- unname(Map(nullToNA,column$value))
+  }
+  unlist(col)
+}
+
+as.data.columns <- function(columns, nrows) {
+  data.columns <- vector("list", length(columns))
+  data.columns <- setNames(data.columns, names(columns))
+  for (colName in names(columns)) {
+    data.columns[[colName]] <- as.data.column(columns[[colName]])
+  }
+  data.columns
+}
+
+nullToNA <- function(val) {
+  if (is.null(val)) {
+    return(NA)
+  } else {
+    return(val)
+  }
+}
+
+
+#' Extract all Form Records, including all Sub-Form Records, in "long" format.
+#' 
+#' The Form Record Table is returned as a data.frame, with: 
+#' - All Form and Sub-Form Record Tables merged into a single table, with missing values given as <NA>.
+#' - Columns for all Form and Sub-Form Fields.
+#' - Rows for each Form and Sub-Form Record. If @param as.value.table is TRUE, each row gives a measured value, specified by the "Quantity" and "Value" fields.
+#' 
+#' @param form.id the full alphanumeric id of the form 
+#' @param as.value.table specify whether to include Quantity/Calculated Fields as separete rows
+#' @param col.names a named character vector containing alternate names for the resulting table
+#' @export
+getFormRecordTable <- function(form.id = NA, as.value.table = FALSE, col.names = NULL) {
+  
+  message("\nFetching Form Tree...")
+  form.tree <- getFormTree(form.id)
+  root.form <- form.tree$forms[[form.tree$root]]
+  root.form.dimensions <- getFormDimensions(root.form)
+  root.form.measures <- getFormMeasures(root.form)
+  
+  message("Fetching Root Form Records...")
+  root.form.records <- getResource(paste("form",root.form$id,"query","columns", sep = "/"))
+  message(paste("Form ",root.form$label, " has ", root.form.records$rows, " records.", sep = ""))
+  
+  message("Fetching Sub-Form Records...")
+  sub.forms <- lapply(root.form$elements, function (element) {
+    if (identical(element$type,"subform")) {
+      sub.form.id <- element$typeParameters$formId
+      sub.form.schema <- form.tree$forms[[sub.form.id]]
+      sub.form.name <- sub.form.schema$label
+      sub.form.dimensions <- getFormDimensions(sub.form.schema, paste(sub.form.name,"",sep="."))
+      sub.form.measures <- getFormMeasures(sub.form.schema, paste(sub.form.name,"",sep="."))
+      
+      sub.form.records <- getResource(paste("form",sub.form.id,"query","columns", sep = "/"),
+                                      c(subFormRecordId = "[_id]", 
+                                        parentId = "[parent]",
+                                        sub.form.dimensions,
+                                        sub.form.measures))
+      message(paste("Sub-Form ",sub.form.name, " has ", sub.form.records$rows, " records.", sep = ""))
+      sub.form.table <- createDataFrame(sub.form.records, 
+                                        sub.form.dimensions, 
+                                        sub.form.measures, 
+                                        as.value.table)
+      
+      # add Sub-Form Id and Name columns
+      sub.form.table$subFormId <- rep(sub.form.id, nrow(sub.form.table))
+      sub.form.table$subFormName <- rep(sub.form.name, nrow(sub.form.table))
+      
+      return(list(id = sub.form.id,
+                  schema = sub.form.schema,
+                  dimensions = sub.form.schema,
+                  measures = sub.form.measures,
+                  records = sub.form.records,
+                  table = sub.form.table))
+    }
+  })
+  sub.forms <- Filter(Negate(is.null), sub.forms)
+  
+  # Create root form data frame - only melt into value table if there are no subforms
+  root.form.table <- createDataFrame(root.form.records, 
+                                     root.form.dimensions, 
+                                     root.form.measures,
+                                     as.value.table && length(sub.forms) == 0)
+  
+  # Correct the Id Field, and add Form Id and Form Name
+  colnames(root.form.table)[names(root.form.table) == "X.id"] <- "recordId"
+  root.form.table$formId <- rep(form.id, times = nrow(root.form.table))
+  root.form.table$formName <- rep(root.form$label)
+  
+  # Check whether we need to merge in Sub-Form Record Tables
+  if (length(sub.forms) > 0 && root.form.records$rows > 0) {
+    # Find common column names for combining all results into a single table, and add missing columns as NAs
+    sub.form.column.names <- Reduce(union, lapply(sub.forms, function(sub.form) names(sub.form$table)))
+    sub.forms <- lapply(sub.forms, function(sub.form) {
+      missing.columns <- setdiff(sub.form.column.names, names(sub.form$table))
+      for (missing.column in missing.columns) {
+        sub.form$table[, missing.column] <- rep(NA, times = nrow(sub.form$table))
+      }
+      sub.form
+    })
+    
+    # Merge all Sub Form Tables into one via a row concatenation
+    sub.form.table <- do.call(rbind, lapply(sub.forms, function(sub.form) sub.form$table))
+    
+    # Merge Sub Form Tables into Root Form Table via a Left Outer Join
+    record.table <- merge(x = root.form.table, y = sub.form.table, by.x = "recordId", by.y = "parentId", all.x = TRUE)
+  } else {
+    record.table <- root.form.table
+  }
+  
+  # Apply column names
+  for(i in seq_along(col.names)) {
+    names(record.table)[ names(record.table) == names(col.names)[i] ] <- col.names[i]
+  }
+  
+  return(record.table)
+}
+
+
+#' Extract all Form Record Tables for a Database in "long" format.
+#' 
+#' Each Form Record Table is returned as a data.frame, with:
+#' - Columns for all Form Fields.
+#' - Rows for each Form Record. If @param as.value.table is TRUE, each row gives a measured value, specified by the "Quantity" and "Value" fields.
+#' 
+#' Returns a list of all Form Record Tables. 
+#' If @param as.single.table is TRUE, all Form Record Tables will be concatenated into a single table, with missing values given as <NA>.
+#' 
+#' @param database.id the numeric id of the database 
+#' @param as.value.table specify whether to include Quantity/Calculated Fields as separete rows
+#' @param as.single.table specify whether to merge all Form Record Tables into a single table
+#' @export
+getDatabaseRecordTable <- function(database.id = NA, as.value.table = FALSE, as.single.table = FALSE) {
+  
+  message("Fetching database schema...")
+  db.schema <- getDatabaseSchema(database.id)
+  
+  message(paste("Database contains ", length(db.schema$activities),
+                " forms. Retrieving data per form...\n", sep = ""))
+  
+  form.records <- lapply(db.schema$activities, function(form) {
+    form.records <- getFormRecordTable(site.form.id(form$id), as.value.table)
+    form.records
+  })
+  
+  if (as.single.table) {
+    # Find common column names for combining all results into a single table:
+    all.column.names <- Reduce(union, lapply(form.records, names))
+    common.column.names <- Reduce(intersect, lapply(form.records, names))
+    
+    missing.columns <- setdiff(all.column.names, common.column.names)
+    if (length(missing.columns) > 0L) {
+      warning("the following column(s) is or are not shared by all forms: ",
+              paste(missing.columns, collapse = ", "))
+    }
+    
+    # Add missing columns as NAs
+    form.records <- lapply(form.records, function(table) {
+      missing.columns <- setdiff(all.column.names, names(table))
+      for(missing.column in missing.columns) {
+        table[, missing.column] <- rep(NA, times = nrow(table))
+      }
+      table
+    })
+    
+    # Combine all data into a single table:
+    values <- do.call(rbind, form.records)
+    
+    values$database.id <- rep(database.id, times = nrow(values))
+    values$database <- rep(db.schema$name, times = nrow(values))
+  } else {
+    values <- form.records
+  }
+  
+  return(values)
+}
+
 
 #' Extract a full database in "long" format
 #' 
@@ -228,7 +463,8 @@ makeColumnName <- function(s, prefix = NULL) {
   
   stopifnot(is.character(s))
   
-  s <- gsub("\\s+|\\.+|-+", "_", trimws(tolower(s)))
+  if(!is.null(prefix)) s <- tolower(s)
+  s <- gsub("\\s+|\\.+|-+", "_", trimws(s))
   s <- gsub("#", "nr", s)
   
   if (is.null(prefix)) {

--- a/R/forms.R
+++ b/R/forms.R
@@ -41,3 +41,12 @@ getFormSchema <- function(formId) {
   stopifnot(is.character(formId))
   getResource(sprintf("form/%s/schema", formId))
 }
+
+#' Queries the Form Tree of a Form
+#' 
+#' @export
+#' @param the formId
+getFormTree <- function(formId) {
+  stopifnot(is.character(formId))
+  getResource(paste("form", formId, "tree", sep = "/"))
+}


### PR DESCRIPTION
Creates two new exported functions:

**getFormRecordTable**
- Creates a long-form record table for a form and its sub-forms
- When present, sub-form records will be:
   Row-concatenated with other sub-form records (with disjoint fields padded with NA), merged via an inner join with the root form dimensions on a recordId<->parentRecordId match, and then row-concatenated with the root form records.
- Measured values are returned as separate row entries, given by the columns "Measure" and their corresponding "Value"

**getDatabaseRecordTable**
- Creates a list of form record tables for a given database
- User can set the **as.single.table** parameter to row-concatenate all of the form record tables into a single table (with disjoint fields padded with NA)