### PR TITLE
Fixes #66. Use direct upload to GCS to avoid import limit.

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -5,10 +5,11 @@
 #' @param data The data.frame to import
 #' @param recordIdColumn The record ID column
 #' @param parentIdColumn The parent ID column required when importing a subform
+#' @param stageDirect Whether the import should be directly staged to Google Cloud Storage. This may not be possible if connecting from Syria or other countries that are blocked from accessing Google services directly. This option is ignored when connecting to a self-managed instance of ActivityInfo.
 #'
 #' @importFrom utils head
 #' @export
-importTable <- function(formId, data, recordIdColumn, parentIdColumn) { 
+importTable <- function(formId, data, recordIdColumn, parentIdColumn, stageDirect = TRUE) { 
   parentId <- NULL
 
   schema <- activityinfo::getFormSchema(formId)
@@ -51,7 +52,7 @@ importTable <- function(formId, data, recordIdColumn, parentIdColumn) {
     recordId <- matchRecordIdsByKey(schema, data, fieldIds, fieldValues)
   }
   lines <- formatImport(data, recordId, parentId, fieldIds, fieldValues)
-  importId <- stageImport(paste(lines, collapse = "\n"))
+  importId <- stageImport(paste(lines, collapse = "\n"), direct = stageDirect)
   
   executeJob("importRecords", descriptor =
                               list(formId = formId,
@@ -345,9 +346,19 @@ formatImport <- function(data, recordId, parentId, fieldIds, fieldValues) {
 #' Stages data to import to ActivityInfo
 #' 
 #' @param text The text of the file to import.
-stageImport <- function(text) {
+#' @param direct Whether the import should be directly staged to Google Cloud Storage. This may not be possible if connecting from Syria or other countries that are blocked from accessing Google services directly. This option is ignored when connecting to a self-managed instance of ActivityInfo.
+stageImport <- function(text, direct = TRUE) {
   
-  url <- paste(activityInfoRootUrl(), "resources", "imports", "stage", sep = "/")
+  if(direct && !grepl(activityInfoRootUrl(), pattern = "www\\.activityinfo\\.org||appspot\\.com")) {
+    warning("Disabling direct import staging for self-managed server")
+    direct <- FALSE
+  }
+  
+  if(direct) {
+    url <- paste(activityInfoRootUrl(), "resources", "imports", "stage", "direct", sep = "/") 
+  } else {
+    url <- paste(activityInfoRootUrl(), "resources", "imports", "stage", sep = "/")
+  }
   
   result <- POST(url, activityInfoAuthentication(), accept_json())
   

--- a/man/importTable.Rd
+++ b/man/importTable.Rd
@@ -4,7 +4,7 @@
 \alias{importTable}
 \title{Batch imports a data.frame into an ActivityInfo form}
 \usage{
-importTable(formId, data, recordIdColumn, parentIdColumn)
+importTable(formId, data, recordIdColumn, parentIdColumn, stageDirect = TRUE)
 }
 \arguments{
 \item{formId}{The form ID}
@@ -14,6 +14,8 @@ importTable(formId, data, recordIdColumn, parentIdColumn)
 \item{recordIdColumn}{The record ID column}
 
 \item{parentIdColumn}{The parent ID column required when importing a subform}
+
+\item{stageDirect}{Whether the import should be directly staged to Google Cloud Storage. This may not be possible if connecting from Syria or other countries that are blocked from accessing Google services directly. This option is ignored when connecting to a self-managed instance of ActivityInfo.}
 }
 \description{
 Batch imports a data.frame into an ActivityInfo form

--- a/man/stageImport.Rd
+++ b/man/stageImport.Rd
@@ -4,10 +4,12 @@
 \alias{stageImport}
 \title{Stages data to import to ActivityInfo}
 \usage{
-stageImport(text)
+stageImport(text, direct = TRUE)
 }
 \arguments{
 \item{text}{The text of the file to import.}
+
+\item{direct}{Whether the import should be directly staged to Google Cloud Storage. This may not be possible if connecting from Syria or other countries that are blocked from accessing Google services directly. This option is ignored when connecting to a self-managed instance of ActivityInfo.}
 }
 \description{
 Stages data to import to ActivityInfo


### PR DESCRIPTION
This updates the importTable() and stageImport() functions to use a signed URL to upload the data to be imported directly to Google Cloud Storage. I have left this as an option because it many users in Syria, Iran, etc are blocked from accessing storage.googleapis.com directly because of sanctions. (Our users are UN agencies and NGOs who are not subject to these sanctions!)