### PR TITLE
AI-3786: Fix tests for attachment type fields

### DIFF
--- a/R/formField.R
+++ b/R/formField.R
@@ -528,7 +528,7 @@ attachmentFieldSchema <- function(label, description = NULL, code = NULL, id = c
       list(
         typeParameters = list(
           "cardinality" = "multiple",
-          "kind" = "attachment"
+          "captureMethods" = list("file", "signature" "camera")
         )
       )
     )

--- a/R/formField.R
+++ b/R/formField.R
@@ -528,7 +528,7 @@ attachmentFieldSchema <- function(label, description = NULL, code = NULL, id = c
       list(
         typeParameters = list(
           "cardinality" = "multiple",
-          "captureMethods" = list("file", "signature" "camera")
+          "captureMethods" = list("file", "signature", "camera")
         )
       )
     )


### PR DESCRIPTION
AI-3786: Update attachmentFieldSchema to use new attachment field type parameters
    - Form field tests on R package require identical request and response JSON for form fields
    - Therefore must update R package test to use new attachment type structure (notably removing "kind" property and including "captureMethods" property)
    - However attachment type deserialisation remains backwards compatible, so users who pass in old structure will not be blocked by the changes to attachment type