### PR TITLE
Handle missing parent billing accounts

### DIFF
--- a/R/billingInfo.R
+++ b/R/billingInfo.R
@@ -13,6 +13,12 @@ getBillingAccount <- function(billingAccountId, asDataFrame = TRUE) {
   
   billingInfo <- getResource(paste0("/billingAccounts/", billingAccountId), task = "Getting billing account info")
   billingInfo$id <- as.character(billingInfo$id)
+  if (is.null(billingInfo$parentBillingAccount)) {
+    billingInfo$parentBillingAccount <- NA
+  } else{
+    billingInfo$parentBillingAccount <- as.character(billingInfo$parentBillingAccount)
+  }
+
   if (asDataFrame == TRUE) {
     billingInfo <- tibble::as_tibble(billingInfo)
     return(billingInfo)
@@ -133,6 +139,11 @@ getDatabaseBillingAccount <- function(databaseId, asDataFrame = TRUE) {
   
   databaseOwner <- getResource(paste0("/databases/", databaseId, "/billingAccount"), task = "Getting database owner")
   databaseOwner$id <- as.character(databaseOwner$id)
+  if (is.null(billingInfo$parentBillingAccount)) {
+    billingInfo$parentBillingAccount <- NA
+  } else{
+    billingInfo$parentBillingAccount <- as.character(billingInfo$parentBillingAccount)
+  }
   
   if (asDataFrame) {
     databaseOwner <- as_tibble(databaseOwner)

--- a/R/billingInfo.R
+++ b/R/billingInfo.R
@@ -15,7 +15,7 @@ getBillingAccount <- function(billingAccountId, asDataFrame = TRUE) {
   billingInfo$id <- as.character(billingInfo$id)
   if (is.null(billingInfo$parentBillingAccount)) {
     billingInfo$parentBillingAccount <- NA
-  } else{
+  } else {
     billingInfo$parentBillingAccount <- as.character(billingInfo$parentBillingAccount)
   }
 
@@ -137,18 +137,18 @@ getDatabaseBillingAccount <- function(databaseId, asDataFrame = TRUE) {
   if(missing(databaseId)) stop("A databaseId must be provided")
   stopifnot("A single databaseId must be provided" = (length(databaseId)==1))
   
-  databaseOwner <- getResource(paste0("/databases/", databaseId, "/billingAccount"), task = "Getting database owner")
-  databaseOwner$id <- as.character(databaseOwner$id)
+  billingInfo <- getResource(paste0("/databases/", databaseId, "/billingAccount"), task = "Getting database billing account")
+  billingInfo$id <- as.character(billingInfo$id)
   if (is.null(billingInfo$parentBillingAccount)) {
     billingInfo$parentBillingAccount <- NA
-  } else{
+  } else {
     billingInfo$parentBillingAccount <- as.character(billingInfo$parentBillingAccount)
   }
-  
+
   if (asDataFrame) {
-    databaseOwner <- as_tibble(databaseOwner)
+    billingInfo <- as_tibble(billingInfo)
   }
-  return(databaseOwner)
+  return(billingInfo)
 }
 
 


### PR DESCRIPTION
New changes to billing accounts in ActivityInfo add optional parent billing account ids. When a billing account does not have a parent, it is returned as a JSON null and is loaded as a NULL when read by the R package.

Unfortunately, the R package currently wants to convert the billing account object to a dataframe for other purposes, which does not accept NULL values in properties. Therefore add special handling to convert missing billing accounts to NA, and convert the parentBillingAccount id to a string as per the normal billing account id.