### PR TITLE
Update query sort modelling

### DIFF
--- a/R/records.R
+++ b/R/records.R
@@ -1221,7 +1221,7 @@ addFilter <- function(x, formulaFilter) {
 #' Usually one would use the [dplyr::arrange] verb instead.
 #'
 #' @param x the remote records object fetched with [activityinfo::getRecords].
-#' @param sort the sort object in the following format: list(list(dir = "ASC", field = "\[Name\]")) or list(list(dir = "DESC", field = "\[Name\]"))
+#' @param sort the sort object in the following format: list(list(dir = "ASC", formula = "\[Name\]")) or list(list(dir = "DESC", formula = "\[Name\]"))
 #' 
 #' @export
 addSort <- function(x, sort) {
@@ -1713,14 +1713,14 @@ arrange.tbl_activityInfoRemoteRecords <- function(.data, ...) {
     if (is.symbol(expr2)) {
       chexpr <- rlang::as_name(expr2)
       if (chexpr %in% tblNames(.data)) {
-        return(addSort(x = .data, sort = list(list(dir = "ASC", field = chexpr))))
+        return(addSort(x = .data, sort = list(list(dir = "ASC", formula = chexpr))))
       }
     } else if (is.call(expr2)) {
       fn <- as.character(expr2[[1]])
       if (fn == "desc") {
         chexpr <- as.character(expr2[[2]])
         if (chexpr %in% tblNames(.data)) {
-          return(addSort(x = .data, sort = list(list(dir = "DESC", field = chexpr))))
+          return(addSort(x = .data, sort = list(list(dir = "DESC", formula = chexpr))))
         }
       }
     }

--- a/R/records.R
+++ b/R/records.R
@@ -1165,12 +1165,12 @@ tbl.src_activityInfo <- function(src, formTree, style = defaultColumnStyle(),...
 }
 
 getTotalLastEditTime <- function(formTree) {
-  df <- queryTable(formTree$root, columns = list("id"="_id", "lastEditTime" = "_lastEditTime"), asTibble = TRUE, makeNames = FALSE, window = c(0L,1L), sort=list(list(dir = "DESC", field = "_lastEditTime")))
+  df <- queryTable(formTree$root, columns = list("id"="_id", "lastEditTime" = "_lastEditTime"), asTibble = TRUE, makeNames = FALSE, window = c(0L,1L), sort=list(list(dir = "DESC", formula = "_lastEditTime")))
   totalRecords <- attr(df, "totalRows")
   if (totalRecords==0) {
     # required to check the formTree as queryTable used in totalRecords does not error if there are no permissions but returns 0 rows
     formTree <- getFormTree(formTree$root)
-    df <- queryTable(formTree$root, columns = list("id"="_id", "lastEditTime" = "_lastEditTime"), asTibble = TRUE, makeNames = FALSE, window = c(0L,1L), sort=list(list(dir = "DESC", field = "_lastEditTime")))
+    df <- queryTable(formTree$root, columns = list("id"="_id", "lastEditTime" = "_lastEditTime"), asTibble = TRUE, makeNames = FALSE, window = c(0L,1L), sort=list(list(dir = "DESC", formula = "_lastEditTime")))
     totalRecords <- attr(df, "totalRows")
   }
   lastEditTime <- df[[1,"lastEditTime"]]

--- a/R/tableQuery.R
+++ b/R/tableQuery.R
@@ -214,9 +214,9 @@ checkSortList <- function(sort) {
   force(sort)
   stopifnot(is.list(sort))
   invisible(lapply(sort, function(x) {
-    stopifnot(all(names(x) %in% c("dir", "field")))
+    stopifnot(all(names(x) %in% c("dir", "formula")))
     stopifnot(x[["dir"]]%in%c("ASC", "DESC"))
-    stopifnot(is.character(x[["field"]]))
+    stopifnot(is.character(x[["formula"]]))
     stopifnot(is.character(x[["dir"]]))
   }))
 }

--- a/man/addSort.Rd
+++ b/man/addSort.Rd
@@ -9,7 +9,7 @@ addSort(x, sort)
 \arguments{
 \item{x}{the remote records object fetched with \link{getRecords}.}
 
-\item{sort}{the sort object in the following format: list(list(dir = "ASC", field = "[Name]")) or list(list(dir = "DESC", field = "[Name]"))}
+\item{sort}{the sort object in the following format: list(list(dir = "ASC", formula = "[Name]")) or list(list(dir = "DESC", formula = "[Name]"))}
 }
 \description{
 This adds a single sorted column to an ActivityInfo remote records object.

--- a/tests/testthat/test-records.R
+++ b/tests/testthat/test-records.R
@@ -1,4 +1,4 @@
-
+  
 
 testthat::test_that("add, update, and deleteRecord() works", {
   
@@ -271,11 +271,11 @@ testthat::test_that("getRecords() works", {
 
   dfA <- rcrds %>% 
     addFilter('[A logical column] == "True"') %>% 
-    addSort(list(list(dir = "ASC", field = "_id"))) %>%
+    addSort(list(list(dir = "ASC", formula = "_id"))) %>%
     adjustWindow(offSet = 0L, limit = 10L) %>% collect()
   dfB <- rcrds %>% 
     filter(`A logical column` == "True") %>% 
-    addSort(list(list(dir = "ASC", field = "_id"))) %>%
+    addSort(list(list(dir = "ASC", formula = "_id"))) %>%
     slice_head(n = 10) %>% collect()
   
   attr(dfA, "remoteRecords") <- NULL
@@ -310,7 +310,7 @@ testthat::test_that("getRecords() works", {
     testthat::expect_warning({
       recordIds <- rcrds %>% 
         addFilter('[A logical column] == "True"') %>% 
-        addSort(list(list(dir = "DESC", field = "A date column"))) %>%
+        addSort(list(list(dir = "DESC", formula = "A date column"))) %>%
         head(n = 10) %>%
         select(`_id`) %>%
         collect() %>%
@@ -333,7 +333,7 @@ testthat::test_that("getRecords() works", {
       rcrds %>% 
         select(id = `_id`, date = `A date column`, logical = `A logical column`) %>%
         filter(logical == "True") %>% rename(date2 = date) %>% 
-        addSort(list(list(dir = "DESC", field = "date"))) %>% 
+        addSort(list(list(dir = "DESC", formula = "date"))) %>% 
         head(10) %>% 
         collect()
     })
@@ -370,7 +370,7 @@ testthat::test_that("getRecords() works", {
     recordIds <- rcrds %>% 
       select(id = `_id`, date = `A date column`, logical = `A logical column`) %>%
       filter(logical == "True") %>% 
-      addSort(list(list(dir = "DESC", field = "date"))) %>% 
+      addSort(list(list(dir = "DESC", formula = "date"))) %>% 
       head(10) %>% 
       collect() %>%
       pull("id")

--- a/tests/testthat/test-records.R
+++ b/tests/testthat/test-records.R
@@ -271,11 +271,11 @@ testthat::test_that("getRecords() works", {
 
   dfA <- rcrds %>% 
     addFilter('[A logical column] == "True"') %>% 
-    addSort(list(list(dir = "ASC", formula = "_id"))) %>%
+    addSort(list(list(dir = "ASC", formula = "[Identifier number]"))) %>%
     adjustWindow(offSet = 0L, limit = 10L) %>% collect()
   dfB <- rcrds %>% 
     filter(`A logical column` == "True") %>% 
-    addSort(list(list(dir = "ASC", formula = "_id"))) %>%
+    addSort(list(list(dir = "ASC", formula = "[Identifier number]"))) %>%
     slice_head(n = 10) %>% collect()
   
   attr(dfA, "remoteRecords") <- NULL
@@ -344,7 +344,7 @@ testthat::test_that("getRecords() works", {
     recordIds <- rcrds %>% 
       select(id = `_id`, date = `A date column`, logical = `A logical column`) %>%
       filter(logical == "True") %>% 
-      addSort(list(list(dir = "DESC", formula = "date"))) %>% 
+      addSort(list(list(dir = "DESC", formula = "[A date column]"))) %>% 
       head(10) %>% 
       collect() %>%
       pull("id")

--- a/tests/testthat/test-records.R
+++ b/tests/testthat/test-records.R
@@ -304,20 +304,6 @@ testthat::test_that("getRecords() works", {
     })
   })
   
-  # removing columns required for a filter will result in an error
-  # expect warning using select after filter or sort
-  testthat::expect_error({
-    testthat::expect_warning({
-      recordIds <- rcrds %>% 
-        addFilter('[A logical column] == "True"') %>% 
-        addSort(list(list(dir = "DESC", formula = "A date column"))) %>%
-        head(n = 10) %>%
-        select(`_id`) %>%
-        collect() %>%
-        pull("_id")
-    })
-  })
-  
   # filters will work even if the column is renamed in a lazy remote records object
   testthat::expect_no_warning({
     rcrds %>% 
@@ -325,18 +311,6 @@ testthat::test_that("getRecords() works", {
       filter(logical == "True") %>% 
       rename(logical2 = logical) %>%
       collect()
-  })
-  
-  # renaming columns required for a sort will result in an error
-  testthat::expect_error({
-    testthat::expect_warning({
-      rcrds %>% 
-        select(id = `_id`, date = `A date column`, logical = `A logical column`) %>%
-        filter(logical == "True") %>% rename(date2 = date) %>% 
-        addSort(list(list(dir = "DESC", formula = "date"))) %>% 
-        head(10) %>% 
-        collect()
-    })
   })
   
   testthat::test_that("Copying of schemas with extractSchemaFromFields()", {


### PR DESCRIPTION
- Update sort model (and docs) to use 'formula'
- Remove incorrect test assertions: filter/sort models can be applied on query via a formula which does not reference column ids